### PR TITLE
Add Discord invite link on login page

### DIFF
--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -22,6 +22,10 @@
     <p class="small text-center mb-4">
       以下の QR コードを読み取ってログインしてください。
     </p>
+    <p class="small text-center">
+      アカウントをお持ちでない方は
+      <a href="https://discord.gg/yurfYA5aQ8" target="_blank" class="fw-medium text-decoration-underline">Discordに参加</a>してください。
+    </p>
     {% if error %}
       <div class="alert alert-danger animate__animated animate__shakeX" role="alert">{{ error }}</div>
     {% endif %}


### PR DESCRIPTION
## Summary
- add note encouraging users to join Discord on PC login page

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876f6af66a0832c993897c872131fa9