### PR TITLE
Implement page-based file list caching

### DIFF
--- a/tests/test_files_per_page.py
+++ b/tests/test_files_per_page.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+
+def test_files_per_page_constant():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert 'FILES_PER_PAGE' in text
+    assert 'LIMIT ? OFFSET ?' in text

--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -89,3 +89,7 @@ def test_cache_version_variable():
     assert 'const CACHE_VERSION' in sw
     pattern = re.compile(r"const CACHE_NAME = `wds-cache-\${CACHE_VERSION}`;")
     assert pattern.search(sw)
+
+def test_precache_first_page():
+    sw = read_sw()
+    assert '/partial/files?page=1' in sw

--- a/web/app.py
+++ b/web/app.py
@@ -79,6 +79,7 @@ DISCORD_CLIENT_SECRET = os.getenv("DISCORD_CLIENT_SECRET")
 # HTTPS 強制リダイレクトの有無
 FORCE_HTTPS = os.getenv("FORCE_HTTPS", "0").lower() in {"1", "true", "yes"}
 DM_UPLOAD_LIMIT = int(os.getenv("DISCORD_DM_UPLOAD_LIMIT", 8 << 20))
+FILES_PER_PAGE = int(os.getenv("FILES_PER_PAGE", 50))
 HTTP_TIMEOUT = aiohttp.ClientTimeout(total=60)
 
 # ─────────────── Helpers ───────────────
@@ -587,11 +588,21 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         # ファイル一覧取得
         # SELECT で expiration_sec も取得する
         folder = request.query.get("folder", "")
+        page = int(request.query.get("page", "1") or "1")
+        if page < 1:
+            page = 1
+        offset = (page - 1) * FILES_PER_PAGE
         rows = await db.fetchall(
-            "SELECT *, expiration_sec, expires_at FROM files WHERE user_id = ? AND folder = ?",
+            "SELECT *, expiration_sec, expires_at FROM files WHERE user_id = ? AND folder = ? "
+            "ORDER BY uploaded_at DESC LIMIT ? OFFSET ?",
             user_id,
             folder,
+            FILES_PER_PAGE + 1,
+            offset,
         )
+        has_next = len(rows) > FILES_PER_PAGE
+        if has_next:
+            rows = rows[:-1]
         now = int(datetime.now(timezone.utc).timestamp())
         file_objs: List[Dict[str, object]] = []
 
@@ -620,7 +631,14 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
 
         # CSRF トークン発行
         token = await issue_csrf(request)
-        return {"files": file_objs, "csrf_token": token, "user_id": discord_id}
+        return {
+            "files": file_objs,
+            "csrf_token": token,
+            "user_id": discord_id,
+            "page": page,
+            "has_next": has_next,
+            "folder_id": folder,
+        }
 
     @aiohttp_jinja2.template("partials/search_results.html")
     async def search_files_api(request: web.Request):
@@ -1254,11 +1272,21 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         username = user_row["username"] if user_row else "Unknown"
         # expiration_sec を含めて取得するように
         folder = req.query.get("folder", "")
+        page = int(req.query.get("page", "1") or "1")
+        if page < 1:
+            page = 1
+        offset = (page - 1) * FILES_PER_PAGE
         rows = await app["db"].fetchall(
-            "SELECT *, expiration_sec, expires_at FROM files WHERE user_id = ? AND folder = ?",
+            "SELECT *, expiration_sec, expires_at FROM files WHERE user_id = ? AND folder = ? "
+            "ORDER BY uploaded_at DESC LIMIT ? OFFSET ?",
             user_id,
             folder,
+            FILES_PER_PAGE + 1,
+            offset,
         )
+        has_next = len(rows) > FILES_PER_PAGE
+        if has_next:
+            rows = rows[:-1]
         parent_id = int(folder) if folder else None
         subfolders = await app["db"].list_user_folders(user_id, parent_id)
         breadcrumbs = []
@@ -1308,6 +1336,8 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
                 "folder_id": folder,
                 "subfolders": subfolders,
                 "breadcrumbs": breadcrumbs,
+                "page": page,
+                "has_next": has_next,
                 "gdrive_enabled": bool(GDRIVE_CREDENTIALS),
                 "gdrive_authorized": (
                     bool(await app["db"].get_gdrive_token(user_id))
@@ -1345,11 +1375,21 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         )
         username = user_row["username"] if user_row else "Unknown"
         folder = req.query.get("folder", "")
+        page = int(req.query.get("page", "1") or "1")
+        if page < 1:
+            page = 1
+        offset = (page - 1) * FILES_PER_PAGE
         rows = await app["db"].fetchall(
-            "SELECT *, expiration_sec, expires_at FROM files WHERE user_id = ? AND folder = ?",
+            "SELECT *, expiration_sec, expires_at FROM files WHERE user_id = ? AND folder = ? "
+            "ORDER BY uploaded_at DESC LIMIT ? OFFSET ?",
             user_id,
             folder,
+            FILES_PER_PAGE + 1,
+            offset,
         )
+        has_next = len(rows) > FILES_PER_PAGE
+        if has_next:
+            rows = rows[:-1]
         parent_id = int(folder) if folder else None
         subfolders = await app["db"].list_user_folders(user_id, parent_id)
         now_ts = int(datetime.now(timezone.utc).timestamp())
@@ -1388,6 +1428,8 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
                 "username": username,
                 "folder_id": folder,
                 "subfolders": subfolders,
+                "page": page,
+                "has_next": has_next,
                 "gdrive_enabled": bool(GDRIVE_CREDENTIALS),
                 "gdrive_authorized": (
                     bool(await app["db"].get_gdrive_token(user_id))

--- a/web/static/service-worker.js
+++ b/web/static/service-worker.js
@@ -11,6 +11,7 @@ const OFFLINE_URLS = [
   '/static/js/main.js',
   '/static/favicon.png',
   '/manifest.json',
+  '/partial/files?page=1',
   // CDN assets for faster LCP on PWA
   'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css',
   'https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/6.4.0/mdb.min.css',

--- a/web/templates/mobile/partials/file_cards.html
+++ b/web/templates/mobile/partials/file_cards.html
@@ -51,3 +51,19 @@
 {% else %}
 <p class="text-center text-muted">ファイルはありません。</p>
 {% endif %}
+{% if page %}
+<nav class="mt-3">
+  <ul class="pagination justify-content-center mb-0">
+    {% if page > 1 %}
+    <li class="page-item">
+      <a class="page-link" data-ajax href="?page={{ page - 1 }}{% if folder_id %}&folder={{ folder_id }}{% endif %}">前へ</a>
+    </li>
+    {% endif %}
+    {% if has_next %}
+    <li class="page-item">
+      <a class="page-link" data-ajax href="?page={{ page + 1 }}{% if folder_id %}&folder={{ folder_id }}{% endif %}">次へ</a>
+    </li>
+    {% endif %}
+  </ul>
+</nav>
+{% endif %}

--- a/web/templates/partials/file_table.html
+++ b/web/templates/partials/file_table.html
@@ -203,3 +203,19 @@
     {% endif %}
   </div>
 </div>
+{% if page %}
+<nav class="mt-3">
+  <ul class="pagination justify-content-center mb-0">
+    {% if page > 1 %}
+    <li class="page-item">
+      <a class="page-link" data-ajax href="?page={{ page - 1 }}{% if folder_id %}&folder={{ folder_id }}{% endif %}">前へ</a>
+    </li>
+    {% endif %}
+    {% if has_next %}
+    <li class="page-item">
+      <a class="page-link" data-ajax href="?page={{ page + 1 }}{% if folder_id %}&folder={{ folder_id }}{% endif %}">次へ</a>
+    </li>
+    {% endif %}
+  </ul>
+</nav>
+{% endif %}


### PR DESCRIPTION
## Summary
- add `FILES_PER_PAGE` constant
- paginate file list queries
- display pagination controls on desktop and mobile views
- precache the first page in the service worker
- test new constant and precache URL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877282e4d3c832c8c824dcaf757821f