### PR TITLE
Optimize file list reload

### DIFF
--- a/tests/test_file_list_partial.py
+++ b/tests/test_file_list_partial.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+APP = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+JS = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'js' / 'main.js'
+
+def test_partial_files_route_exists():
+    text = APP.read_text(encoding='utf-8')
+    assert '/partial/files' in text
+
+def test_reload_uses_partial_route():
+    text = JS.read_text(encoding='utf-8')
+    assert '/partial/files' in text

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -146,21 +146,24 @@ async function reloadFileList() {
   const isShared = fldInput?.dataset.shared === "1";
   const url      = isShared && folderId
                      ? `/shared/${folderId}`
-                     : window.location.pathname + window.location.search;
+                     : `/partial/files${folderId ? `?folder=${folderId}` : ''}`;
 
   try {
     const res  = await fetch(url, { credentials: "same-origin" });
     if (!res.ok) throw new Error("一覧取得失敗: HTTP " + res.status);
 
     const html = await res.text();
-    // フルページ取得か部分断片か両方に対応
-    const parser  = new DOMParser();
-    const doc     = parser.parseFromString(html, "text/html");
-    const newCont = doc.getElementById("fileListContainer");
-    container.innerHTML = newCont ? newCont.innerHTML : html;
-    if (folderBlock) {
-      const newFolders = doc.getElementById("subfolderList");
-      folderBlock.innerHTML = newFolders ? newFolders.innerHTML : "";
+    if (url.startsWith('/partial/files')) {
+      container.innerHTML = html;
+    } else {
+      const parser  = new DOMParser();
+      const doc     = parser.parseFromString(html, "text/html");
+      const newCont = doc.getElementById("fileListContainer");
+      container.innerHTML = newCont ? newCont.innerHTML : html;
+      if (folderBlock) {
+        const newFolders = doc.getElementById("subfolderList");
+        folderBlock.innerHTML = newFolders ? newFolders.innerHTML : "";
+      }
     }
 
     // 再初期化：Tilt, Ripple, Tooltip など


### PR DESCRIPTION
## Summary
- use `/partial/files` endpoint when reloading file list
- add tests for partial endpoint usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687725b01890832cb8358860444044f4