### PR TITLE
Update Discord OAuth state handling

### DIFF
--- a/tests/test_discord_state.py
+++ b/tests/test_discord_state.py
@@ -3,6 +3,7 @@ from pathlib import Path
 APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
 
 
-def test_discord_states_defined():
+def test_oauth_state_session_storage():
     content = APP_PATH.read_text(encoding='utf-8')
-    assert 'discord_states' in content
+    assert 'sess["oauth_state"]' in content
+    assert 'sess.pop("oauth_state"' in content


### PR DESCRIPTION
## Summary
- store Discord OAuth `state` in user session instead of the app object
- update corresponding test to check session storage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687798552504832cbe8149d66f3848f3