### PR TITLE
Ensure previews always load

### DIFF
--- a/web/templates/mobile/partials/file_cards.html
+++ b/web/templates/mobile/partials/file_cards.html
@@ -4,9 +4,9 @@
   <div class="card file-card">
     <div class="card-body">
       {% if f.is_image %}
-      <img data-src="{{ f.preview_url }}" loading="lazy" class="rounded lazy-preview" onerror="previewError(this)">
+      <img src="{{ f.preview_url }}" class="rounded lazy-preview" onerror="previewError(this)">
       {% elif f.is_video %}
-      <video data-src="{{ f.preview_url }}" preload="metadata" class="rounded lazy-preview" muted autoplay loop playsinline></video>
+      <video src="{{ f.preview_url }}" preload="metadata" class="rounded lazy-preview" muted autoplay loop playsinline></video>
       {% else %}
       <i class="bi {{ icon_by_ext(f.original_name) }} fs-3 text-secondary"></i>
       {% endif %}

--- a/web/templates/mobile/partials/shared_folder_cards.html
+++ b/web/templates/mobile/partials/shared_folder_cards.html
@@ -4,9 +4,9 @@
   <div class="card file-card">
     <div class="card-body">
       {% if f.is_image %}
-      <img data-src="{{ f.preview_url }}" loading="lazy" class="rounded lazy-preview" onerror="previewError(this)">
+      <img src="{{ f.preview_url }}" class="rounded lazy-preview" onerror="previewError(this)">
       {% elif f.is_video %}
-      <video data-src="{{ f.preview_url }}" preload="metadata" class="rounded lazy-preview" muted autoplay loop playsinline></video>
+      <video src="{{ f.preview_url }}" preload="metadata" class="rounded lazy-preview" muted autoplay loop playsinline></video>
       {% else %}
       <i class="bi {{ icon_by_ext(f.original_name) }} fs-3 text-secondary"></i>
       {% endif %}

--- a/web/templates/partials/file_table.html
+++ b/web/templates/partials/file_table.html
@@ -47,7 +47,7 @@
                   <button class="btn btn-outline-secondary p-0 border-0"
                           style="width:60px;height:60px"
                           onclick="showFull('{{ f.download_path }}?preview=1'); return false;">
-                    <img data-src="{{ f.preview_url }}" loading="lazy"
+                    <img src="{{ f.preview_url }}"
                           class="img-fluid rounded lazy-preview" style="max-height:60px;"
                           onerror="previewError(this)">
                     <i class="bi {{ icon_by_ext(f.original_name) }} fs-2 text-secondary fallback-icon d-none"></i>
@@ -59,7 +59,7 @@
                     <button class="btn btn-outline-secondary p-0 border-0"
                             style="width:60px;height:60px"
                             onclick="showFull('{{ f.hls_url or (f.download_path + '?preview=1') }}', true)">
-                      <video data-src="{{ f.preview_url }}" preload="metadata" loading="lazy"
+                      <video src="{{ f.preview_url }}" preload="metadata"
                               class="w-100 h-100 rounded object-fit-cover lazy-preview"
                               style="max-width:60px;max-height:60px;"
                               muted autoplay loop playsinline onerror="previewError(this)"></video>
@@ -71,7 +71,7 @@
                     <button class="btn btn-outline-secondary p-0 border-0"
                             style="width:60px;height:60px"
                             onclick="showFull('{{ f.preview_url }}'); return false;">
-                    <img data-src="{{ f.preview_url }}" loading="lazy"
+                    <img src="{{ f.preview_url }}"
                          class="img-fluid rounded lazy-preview" style="max-height:60px;"
                          onerror="previewError(this)">
                     <i class="bi {{ icon_by_ext(f.original_name) }} fs-2 text-secondary fallback-icon d-none"></i>

--- a/web/templates/partials/shared_folder_table.html
+++ b/web/templates/partials/shared_folder_table.html
@@ -47,7 +47,7 @@
                 <button class="btn btn-outline-secondary p-0 border-0"
                         style="width:60px;height:60px"
                         onclick="showFull('{{ f.download_path }}?preview=1'); return false;">
-                  <img data-src="{{ f.preview_url }}" loading="lazy"
+                  <img src="{{ f.preview_url }}"
                       class="img-fluid rounded lazy-preview"
                       style="max-height:60px;" onerror="previewError(this)">
                   <i class="bi {{ icon_by_ext(f.original_name) }} fs-2 text-secondary fallback-icon d-none"></i>
@@ -59,7 +59,7 @@
                 <button class="btn btn-outline-secondary p-0 border-0"
                         style="width:60px;height:60px"
                         onclick="showFull('{{ f.hls_url or (f.download_path + '?preview=1') }}', true); return false;">
-                  <video data-src="{{ f.preview_url }}" preload="metadata" loading="lazy"
+                  <video src="{{ f.preview_url }}" preload="metadata"
                           class="w-100 h-100 rounded object-fit-cover lazy-preview"
                           style="max-width:60px;max-height:60px;"
                           muted autoplay loop playsinline onerror="previewError(this)"></video>
@@ -71,7 +71,7 @@
                 <button class="btn btn-outline-secondary p-0 border-0"
                         style="width:60px;height:60px"
                         onclick="showFull('{{ f.preview_url }}'); return false;">
-                  <img data-src="{{ f.preview_url }}" loading="lazy"
+                  <img src="{{ f.preview_url }}"
                        class="img-fluid rounded lazy-preview" style="max-height:60px;" onerror="previewError(this)">
                   <i class="bi {{ icon_by_ext(f.original_name) }} fs-2 text-secondary fallback-icon d-none"></i>
                 </button>


### PR DESCRIPTION
## Summary
- change preview elements to load images/videos immediately
- keep existing `lazy-preview` class but remove lazy loading attributes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68779e57ce10832cb2cb3d4ff22e3fde