### PR TITLE
Fix gdrive OAuth state handling

### DIFF
--- a/tests/test_gdrive_callback_invalid_state.py
+++ b/tests/test_gdrive_callback_invalid_state.py
@@ -3,8 +3,8 @@ from pathlib import Path
 APP = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
 
 
-def test_gdrive_callback_calls_gdrive_auth_on_invalid_state():
+def test_gdrive_callback_redirects_on_invalid_state():
     lines = APP.read_text(encoding='utf-8').splitlines()
     start = next(i for i, l in enumerate(lines) if 'async def gdrive_callback' in l)
     snippet = '\n'.join(lines[start:start + 20])
-    assert 'await gdrive_auth(req)' in snippet
+    assert '"/gdrive_auth")' in snippet

--- a/tests/test_gdrive_callback_invalid_state.py
+++ b/tests/test_gdrive_callback_invalid_state.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+APP = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+
+def test_gdrive_callback_redirects_on_invalid_state():
+    lines = APP.read_text(encoding='utf-8').splitlines()
+    start = next(i for i, l in enumerate(lines) if 'async def gdrive_callback' in l)
+    snippet = '\n'.join(lines[start:start + 20])
+    assert 'HTTPFound("/gdrive_auth")' in snippet

--- a/tests/test_gdrive_callback_invalid_state.py
+++ b/tests/test_gdrive_callback_invalid_state.py
@@ -3,8 +3,8 @@ from pathlib import Path
 APP = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
 
 
-def test_gdrive_callback_redirects_on_invalid_state():
+def test_gdrive_callback_calls_gdrive_auth_on_invalid_state():
     lines = APP.read_text(encoding='utf-8').splitlines()
     start = next(i for i, l in enumerate(lines) if 'async def gdrive_callback' in l)
     snippet = '\n'.join(lines[start:start + 20])
-    assert 'HTTPFound("/gdrive_auth")' in snippet
+    assert 'await gdrive_auth(req)' in snippet

--- a/web/app.py
+++ b/web/app.py
@@ -1229,7 +1229,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         state = req.query.get("state")
         sess_state = sess.pop("gdrive_state", None)
         if not state or sess_state != state:
-            raise web.HTTPFound("/gdrive_auth")
+            return await gdrive_auth(req)
         public_domain = os.getenv("PUBLIC_DOMAIN", "localhost:9040")
         redirect_uri = f"https://{public_domain}/gdrive_callback"
         from integrations.google_drive_client import build_flow

--- a/web/app.py
+++ b/web/app.py
@@ -1229,7 +1229,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         state = req.query.get("state")
         sess_state = sess.pop("gdrive_state", None)
         if not state or sess_state != state:
-            return await gdrive_auth(req)
+            raise web.HTTPFound("/gdrive_auth")
         public_domain = os.getenv("PUBLIC_DOMAIN", "localhost:9040")
         redirect_uri = f"https://{public_domain}/gdrive_callback"
         from integrations.google_drive_client import build_flow

--- a/web/app.py
+++ b/web/app.py
@@ -1229,7 +1229,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         state = req.query.get("state")
         sess_state = sess.pop("gdrive_state", None)
         if not state or sess_state != state:
-            return web.Response(text="invalid state", status=400)
+            raise web.HTTPFound("/gdrive_auth")
         public_domain = os.getenv("PUBLIC_DOMAIN", "localhost:9040")
         redirect_uri = f"https://{public_domain}/gdrive_callback"
         from integrations.google_drive_client import build_flow


### PR DESCRIPTION
## Summary
- redirect to `/gdrive_auth` when the callback `state` is invalid
- test that callback redirection is present in `web/app.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877bb1abaf8832c99f05f8303fb6d1d