### PR TITLE
Handle GDrive state mismatch

### DIFF
--- a/tests/test_gdrive_callback_invalid_state.py
+++ b/tests/test_gdrive_callback_invalid_state.py
@@ -8,3 +8,4 @@ def test_gdrive_callback_redirects_on_invalid_state():
     start = next(i for i, l in enumerate(lines) if 'async def gdrive_callback' in l)
     snippet = '\n'.join(lines[start:start + 20])
     assert '"/gdrive_auth")' in snippet
+    assert 'sess.invalidate()' in snippet

--- a/web/app.py
+++ b/web/app.py
@@ -1229,6 +1229,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         state = req.query.get("state")
         sess_state = sess.pop("gdrive_state", None)
         if not state or sess_state != state:
+            sess.invalidate()
             raise web.HTTPFound("/gdrive_auth")
         public_domain = os.getenv("PUBLIC_DOMAIN", "localhost:9040")
         redirect_uri = f"https://{public_domain}/gdrive_callback"


### PR DESCRIPTION
## Summary
- clear the user session if the OAuth state does not match
- test that the callback invalidates the session on mismatch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877d68bfbc0832c8a6f63f223f8fd61