### PR TITLE
ZIP ダウンロードをサブドメイン経由に変更

### DIFF
--- a/tests/test_zip_download_domain.py
+++ b/tests/test_zip_download_domain.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+TEMPLATE_SHARED = Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'shared' / 'folder_view.html'
+TEMPLATE_MOBILE = Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'mobile' / 'folder_view.html'
+
+
+def test_zip_url_variable_defined():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert "zip_url = _make_download_url(f\"/zip/{folder_id}\", external=True)" in text
+
+
+def test_templates_use_zip_url():
+    shared = TEMPLATE_SHARED.read_text(encoding='utf-8')
+    mobile = TEMPLATE_MOBILE.read_text(encoding='utf-8')
+    assert '{{ zip_url }}' in shared
+    assert '{{ zip_url }}' in mobile

--- a/web/app.py
+++ b/web/app.py
@@ -842,11 +842,13 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
             discord_id,
         )
         # ── 5. コンテキスト返却 ──
+        zip_url = _make_download_url(f"/zip/{folder_id}", external=True)
         return _render(
             request,
             "shared/folder_view.html",
             {
                 "folder_id": folder_id,
+                "zip_url": zip_url,
                 "user_id": current_user_id,
                 "request": request,
                 "base_url": base_url,

--- a/web/templates/mobile/folder_view.html
+++ b/web/templates/mobile/folder_view.html
@@ -33,7 +33,7 @@
 
 <div class="mt-3 text-end">
   <a href="/shared" class="btn btn-outline-primary btn-sm me-1">戻る</a>
-  <a href="/zip/{{ folder_id }}" class="btn btn-outline-secondary btn-sm me-1" target="_blank" rel="noopener">ZIP</a>
+  <a href="{{ zip_url }}" class="btn btn-outline-secondary btn-sm me-1" target="_blank" rel="noopener">ZIP</a>
   <a href="/" class="btn btn-outline-primary btn-sm">ホーム</a>
 </div>
 {% endblock %}

--- a/web/templates/shared/folder_view.html
+++ b/web/templates/shared/folder_view.html
@@ -112,7 +112,7 @@
          data-mdb-ripple-init>
         <i class="bi bi-arrow-left-circle me-1"></i>フォルダ一覧へ
       </a>
-      <a href="/zip/{{ folder_id }}"
+      <a href="{{ zip_url }}"
          class="btn btn-outline-secondary ripple me-2"
          target="_blank" rel="noopener"
          data-mdb-ripple-init>


### PR DESCRIPTION
## Summary
- ZIPダウンロードもDOWNLOAD_DOMAINを使う
- テンプレートをzip_url変数に変更
- 新しいpytestを追加

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e953ad6c832ca8ea2650ba6814e1