### PR TITLE
Enhance Google Drive import page UI

### DIFF
--- a/tests/test_gdrive_import_ui.py
+++ b/tests/test_gdrive_import_ui.py
@@ -9,6 +9,7 @@ def test_manual_form_removed():
     html = TEMPLATE.read_text(encoding='utf-8')
     assert 'ファイルIDまたは共有リンク' not in html
     assert 'name="file_id"' not in html
+    assert 'list-group' in html
 
 
 def test_mobile_matches_pc():
@@ -16,11 +17,13 @@ def test_mobile_matches_pc():
     assert 'ファイルIDまたは共有リンク' not in html
     assert 'name="file_id"' not in html
     assert 'id="driveFileList"' in html
+    assert 'list-group' in html
 
 
 def test_import_refreshes_list():
     text = JS_PATH.read_text(encoding='utf-8')
     assert text.count('loadFiles(') >= 5
+    assert 'iconByName' in text
 
 
 def test_back_link_ajax():

--- a/web/static/js/gdrive_import.js
+++ b/web/static/js/gdrive_import.js
@@ -5,6 +5,25 @@ document.addEventListener('DOMContentLoaded', () => {
   const searchInput = document.getElementById('searchQuery');
   if (!list) return;
 
+  function iconByName(name) {
+    const ext = name.includes('.') ? name.split('.').pop().toLowerCase() : '';
+    const map = {
+      jpg: 'bi-file-earmark-image',
+      jpeg: 'bi-file-earmark-image',
+      png: 'bi-file-earmark-image',
+      gif: 'bi-file-earmark-image',
+      mp4: 'bi-file-earmark-play',
+      mov: 'bi-file-earmark-play',
+      mp3: 'bi-file-earmark-music',
+      wav: 'bi-file-earmark-music',
+      pdf: 'bi-file-earmark-pdf',
+      zip: 'bi-file-earmark-zip',
+      rar: 'bi-file-earmark-zip',
+      '7z': 'bi-file-earmark-zip'
+    };
+    return map[ext] || 'bi-file-earmark';
+  }
+
   async function importFile(fileId, filename = '', btn = null) {
     if (!result) return;
     result.textContent = '';
@@ -53,28 +72,32 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function loadFiles(query = '') {
     if (!list) return;
-    list.textContent = 'loading...';
+    list.innerHTML = '<div class="text-center text-muted">loading...</div>';
     try {
       const url = query ? `/gdrive_files?q=${encodeURIComponent(query)}` : '/gdrive_files';
-      const res = await fetch(url, {credentials: 'same-origin'});
+      const res = await fetch(url, { credentials: 'same-origin' });
       const data = await res.json();
       if (!res.ok || !data.success) throw new Error(data.error || 'error');
       list.textContent = '';
       data.files.forEach(f => {
-        const div = document.createElement('div');
-        div.className = 'd-flex align-items-center mb-2';
+        const item = document.createElement('div');
+        item.className = 'list-group-item d-flex align-items-center';
+        const icon = document.createElement('i');
+        icon.className = 'bi ' + iconByName(f.name) + ' me-2';
+        item.appendChild(icon);
         const span = document.createElement('span');
+        span.className = 'flex-grow-1 text-truncate';
         span.textContent = f.name;
-        div.appendChild(span);
+        item.appendChild(span);
         const btn = document.createElement('button');
-        btn.className = 'btn btn-sm btn-primary ms-auto';
+        btn.className = 'btn btn-sm btn-outline-primary ms-auto';
         btn.textContent = '取り込み';
         btn.addEventListener('click', () => importFile(f.id, f.name, btn));
-        div.appendChild(btn);
-        list.appendChild(div);
+        item.appendChild(btn);
+        list.appendChild(item);
       });
     } catch (err) {
-      list.textContent = `一覧取得に失敗しました: ${err.message}`;
+      list.innerHTML = `<div class="text-danger">一覧取得に失敗しました: ${err.message}</div>`;
     }
   }
 

--- a/web/templates/gdrive_import.html
+++ b/web/templates/gdrive_import.html
@@ -6,13 +6,13 @@
     <div class="card-header bg-primary text-white">Google Drive 取り込み</div>
     <div class="card-body">
       <div id="gdriveResult" class="mb-3"></div>
-      <hr>
-      <div class="input-group mb-2">
+      <div class="input-group mb-3">
+        <span class="input-group-text"><i class="bi bi-search"></i></span>
         <input id="searchQuery" type="text" class="form-control" placeholder="ファイル名検索">
         <button id="refreshFiles" type="button" class="btn btn-outline-secondary">最新</button>
       </div>
-      <div id="driveFileList"></div>
-      <a href="/" class="btn btn-link mt-3" data-ajax>&larr; 個人フォルダに戻る</a>
+      <div id="driveFileList" class="list-group mb-3"></div>
+      <a href="/" class="btn btn-link" data-ajax>&larr; 個人フォルダに戻る</a>
     </div>
   </div>
 </div>

--- a/web/templates/mobile/gdrive_import.html
+++ b/web/templates/mobile/gdrive_import.html
@@ -4,13 +4,13 @@
 {% block content %}
 <h2 class="h4 mb-3">Google Drive 取り込み</h2>
 <div id="gdriveResult" class="mb-3"></div>
-<hr>
-<div class="input-group mb-2">
+<div class="input-group mb-3">
+  <span class="input-group-text"><i class="bi bi-search"></i></span>
   <input id="searchQuery" type="text" class="form-control" placeholder="ファイル名検索">
   <button id="refreshFiles" type="button" class="btn btn-outline-secondary">最新</button>
 </div>
-<div id="driveFileList"></div>
-<a href="/" class="btn btn-link mt-3" data-ajax>&larr; 個人フォルダに戻る</a>
+<div id="driveFileList" class="list-group mb-3"></div>
+<a href="/" class="btn btn-link" data-ajax>&larr; 個人フォルダに戻る</a>
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION
## Summary
- revamp Google Drive import pages with a list-group layout and search icon
- show icons per file type and modernize loading in `gdrive_import.js`
- add tests for updated markup and JS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877eef226d8832cb6c45c3e5a4fe131