### PR TITLE
GoogleDrive ファイル名の省略処理を早期化

### DIFF
--- a/tests/test_gdrive_import_ui.py
+++ b/tests/test_gdrive_import_ui.py
@@ -9,6 +9,7 @@ def test_manual_form_removed():
     html = TEMPLATE.read_text(encoding='utf-8')
     assert 'ファイルIDまたは共有リンク' not in html
     assert 'name="file_id"' not in html
+    assert 'list-group' in html
 
 
 def test_mobile_matches_pc():
@@ -16,11 +17,14 @@ def test_mobile_matches_pc():
     assert 'ファイルIDまたは共有リンク' not in html
     assert 'name="file_id"' not in html
     assert 'id="driveFileList"' in html
+    assert 'list-group' in html
 
 
 def test_import_refreshes_list():
     text = JS_PATH.read_text(encoding='utf-8')
     assert text.count('loadFiles(') >= 5
+    assert 'iconByName' in text
+    assert 'truncateName' in text
 
 
 def test_back_link_ajax():
@@ -28,4 +32,20 @@ def test_back_link_ajax():
     mobile = MOBILE_TEMPLATE.read_text(encoding='utf-8')
     assert 'data-ajax' in pc
     assert 'data-ajax' in mobile
+
+
+def test_clear_button_and_spinner():
+    pc = TEMPLATE.read_text(encoding='utf-8')
+    mobile = MOBILE_TEMPLATE.read_text(encoding='utf-8')
+    js = JS_PATH.read_text(encoding='utf-8')
+    assert 'clearSearch' in pc
+    assert 'clearSearch' in mobile
+    assert 'spinner-border' in js
+    assert 'list-group-item-action' in js
+    assert 'flex-shrink-0' in js
+
+
+def test_pc_width():
+    html = TEMPLATE.read_text(encoding='utf-8')
+    assert 'max-width:640px' in html
 

--- a/web/static/js/gdrive_import.js
+++ b/web/static/js/gdrive_import.js
@@ -3,7 +3,31 @@ document.addEventListener('DOMContentLoaded', () => {
   const list = document.getElementById('driveFileList');
   const refreshBtn = document.getElementById('refreshFiles');
   const searchInput = document.getElementById('searchQuery');
+  const clearBtn = document.getElementById('clearSearch');
   if (!list) return;
+
+  function truncateName(name, limit = 40) {
+    return name.length > limit ? name.slice(0, limit) + '…' : name;
+  }
+
+  function iconByName(name) {
+    const ext = name.includes('.') ? name.split('.').pop().toLowerCase() : '';
+    const map = {
+      jpg: 'bi-file-earmark-image',
+      jpeg: 'bi-file-earmark-image',
+      png: 'bi-file-earmark-image',
+      gif: 'bi-file-earmark-image',
+      mp4: 'bi-file-earmark-play',
+      mov: 'bi-file-earmark-play',
+      mp3: 'bi-file-earmark-music',
+      wav: 'bi-file-earmark-music',
+      pdf: 'bi-file-earmark-pdf',
+      zip: 'bi-file-earmark-zip',
+      rar: 'bi-file-earmark-zip',
+      '7z': 'bi-file-earmark-zip'
+    };
+    return map[ext] || 'bi-file-earmark';
+  }
 
   async function importFile(fileId, filename = '', btn = null) {
     if (!result) return;
@@ -53,28 +77,39 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function loadFiles(query = '') {
     if (!list) return;
-    list.textContent = 'loading...';
+    list.innerHTML = '<div class="d-flex justify-content-center my-3"><div class="spinner-border text-secondary" role="status"></div></div>';
     try {
       const url = query ? `/gdrive_files?q=${encodeURIComponent(query)}` : '/gdrive_files';
-      const res = await fetch(url, {credentials: 'same-origin'});
+      const res = await fetch(url, { credentials: 'same-origin' });
       const data = await res.json();
       if (!res.ok || !data.success) throw new Error(data.error || 'error');
       list.textContent = '';
+      if (data.files.length === 0) {
+        list.innerHTML = '<div class="text-center text-muted">ファイルが見つかりません</div>';
+        return;
+      }
       data.files.forEach(f => {
-        const div = document.createElement('div');
-        div.className = 'd-flex align-items-center mb-2';
+        const item = document.createElement('div');
+        item.className = 'list-group-item list-group-item-action d-flex align-items-center';
+        const icon = document.createElement('i');
+        icon.className = 'bi ' + iconByName(f.name) + ' me-2';
+        item.appendChild(icon);
         const span = document.createElement('span');
-        span.textContent = f.name;
-        div.appendChild(span);
+        span.className = 'flex-grow-1 text-truncate';
+        span.style.minWidth = '0';
+        span.textContent = truncateName(f.name);
+        span.title = f.name;
+        item.appendChild(span);
         const btn = document.createElement('button');
-        btn.className = 'btn btn-sm btn-primary ms-auto';
+        btn.className = 'btn btn-sm btn-outline-primary ms-auto flex-shrink-0';
+        btn.style.minWidth = '6em';
         btn.textContent = '取り込み';
         btn.addEventListener('click', () => importFile(f.id, f.name, btn));
-        div.appendChild(btn);
-        list.appendChild(div);
+        item.appendChild(btn);
+        list.appendChild(item);
       });
     } catch (err) {
-      list.textContent = `一覧取得に失敗しました: ${err.message}`;
+      list.innerHTML = `<div class="text-danger">一覧取得に失敗しました: ${err.message}</div>`;
     }
   }
 
@@ -83,14 +118,27 @@ document.addEventListener('DOMContentLoaded', () => {
     let timer;
     const triggerSearch = () => {
       clearTimeout(timer);
-      timer = setTimeout(
-        () => loadFiles(searchInput.value.trim()),
-        500
-      );
+      timer = setTimeout(() => loadFiles(searchInput.value.trim()), 500);
     };
-    searchInput.addEventListener('input', triggerSearch);
+    const updateClear = () => {
+      if (clearBtn) clearBtn.classList.toggle('d-none', !searchInput.value);
+    };
+    searchInput.addEventListener('input', () => {
+      updateClear();
+      triggerSearch();
+    });
     searchInput.addEventListener('keydown', e => {
       if (e.key === 'Enter') e.preventDefault();
+    });
+    updateClear();
+  }
+  if (clearBtn) {
+    clearBtn.addEventListener('click', () => {
+      if (searchInput) {
+        searchInput.value = '';
+        clearBtn.classList.add('d-none');
+      }
+      loadFiles();
     });
   }
   loadFiles();

--- a/web/templates/gdrive_import.html
+++ b/web/templates/gdrive_import.html
@@ -2,17 +2,18 @@
 {% block title %}Google Drive 取り込み{% endblock %}
 {% block content %}
 <div class="container py-5">
-  <div class="card mx-auto" style="max-width:480px;">
+  <div class="card mx-auto" style="max-width:640px;">
     <div class="card-header bg-primary text-white">Google Drive 取り込み</div>
     <div class="card-body">
       <div id="gdriveResult" class="mb-3"></div>
-      <hr>
-      <div class="input-group mb-2">
+      <div class="input-group mb-3">
+        <span class="input-group-text"><i class="bi bi-search"></i></span>
         <input id="searchQuery" type="text" class="form-control" placeholder="ファイル名検索">
+        <button id="clearSearch" type="button" class="btn btn-outline-secondary d-none"><i class="bi bi-x-lg"></i></button>
         <button id="refreshFiles" type="button" class="btn btn-outline-secondary">最新</button>
       </div>
-      <div id="driveFileList"></div>
-      <a href="/" class="btn btn-link mt-3" data-ajax>&larr; 個人フォルダに戻る</a>
+      <div id="driveFileList" class="list-group mb-3"></div>
+      <a href="/" class="btn btn-link" data-ajax>&larr; 個人フォルダに戻る</a>
     </div>
   </div>
 </div>

--- a/web/templates/mobile/gdrive_import.html
+++ b/web/templates/mobile/gdrive_import.html
@@ -4,13 +4,14 @@
 {% block content %}
 <h2 class="h4 mb-3">Google Drive 取り込み</h2>
 <div id="gdriveResult" class="mb-3"></div>
-<hr>
-<div class="input-group mb-2">
+<div class="input-group mb-3">
+  <span class="input-group-text"><i class="bi bi-search"></i></span>
   <input id="searchQuery" type="text" class="form-control" placeholder="ファイル名検索">
+  <button id="clearSearch" type="button" class="btn btn-outline-secondary d-none"><i class="bi bi-x-lg"></i></button>
   <button id="refreshFiles" type="button" class="btn btn-outline-secondary">最新</button>
 </div>
-<div id="driveFileList"></div>
-<a href="/" class="btn btn-link mt-3" data-ajax>&larr; 個人フォルダに戻る</a>
+<div id="driveFileList" class="list-group mb-3"></div>
+<a href="/" class="btn btn-link" data-ajax>&larr; 個人フォルダに戻る</a>
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION
## Summary
- `truncateName` 関数を追加し、ファイル名を挿入する前に省略処理を実行
- 省略前の名前は `title` 属性に保持
- テストを更新し `truncateName` の存在を確認

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877eef226d8832cb6c45c3e5a4fe131