### PR TITLE
Improve breadcrumb style

### DIFF
--- a/tests/test_breadcrumb_style.py
+++ b/tests/test_breadcrumb_style.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+CSS = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'css' / 'style-fresh.css'
+TEMPLATES = [
+    Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'index.html',
+    Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'partials' / 'home.html',
+    Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'shared' / 'folder_view.html',
+    Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'shared' / 'index.html',
+    Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'mobile' / 'folder_view.html',
+]
+
+def test_css_has_breadcrumb_pills():
+    text = CSS.read_text(encoding='utf-8')
+    assert '.breadcrumb-pills' in text
+    assert '\\F285' in text
+
+def test_templates_use_breadcrumb_pills():
+    for tpl in TEMPLATES:
+        html = tpl.read_text(encoding='utf-8')
+        assert 'breadcrumb-pills' in html

--- a/web/static/css/style-fresh.css
+++ b/web/static/css/style-fresh.css
@@ -435,3 +435,27 @@ body.dark-mode #fileSearch {
 body.dark-mode .expiration-cell small {
   color: var(--text-color-dark);
 }
+
+/* ── Breadcrumb Pills ── */
+.breadcrumb-pills .breadcrumb-item {
+  background-color: var(--card-bg-light);
+  color: var(--text-color-light);
+  padding: 0.25rem 0.75rem;
+  border-radius: 2rem;
+}
+.breadcrumb-pills .breadcrumb-item + .breadcrumb-item {
+  margin-left: 0.5rem;
+}
+.breadcrumb-pills .breadcrumb-item + .breadcrumb-item::before {
+  content: "\F285";
+  font-family: "bootstrap-icons";
+  color: var(--link-color-light);
+  padding-right: 0.25rem;
+}
+body.dark-mode .breadcrumb-pills .breadcrumb-item {
+  background-color: var(--card-bg-dark);
+  color: var(--text-color-dark);
+}
+body.dark-mode .breadcrumb-pills .breadcrumb-item + .breadcrumb-item::before {
+  color: var(--link-color-dark);
+}

--- a/web/static/css/style-mobile-friendly.css
+++ b/web/static/css/style-mobile-friendly.css
@@ -75,3 +75,27 @@ body.dark-mode #sendModal .form-control {
   color: #ffffff;
   border-color: #444556;
 }
+
+/* ── Breadcrumb Pills ── */
+.breadcrumb-pills .breadcrumb-item {
+  background-color: #f2f4f6;
+  color: #212529;
+  padding: 0.25rem 0.75rem;
+  border-radius: 2rem;
+}
+.breadcrumb-pills .breadcrumb-item + .breadcrumb-item {
+  margin-left: 0.5rem;
+}
+.breadcrumb-pills .breadcrumb-item + .breadcrumb-item::before {
+  content: "\F285";
+  font-family: "bootstrap-icons";
+  color: #0d6efd;
+  padding-right: 0.25rem;
+}
+body.dark-mode .breadcrumb-pills .breadcrumb-item {
+  background-color: #2e3038;
+  color: #f5f5f5;
+}
+body.dark-mode .breadcrumb-pills .breadcrumb-item + .breadcrumb-item::before {
+  color: #64b5f6;
+}

--- a/web/static/css/style-mobile.css
+++ b/web/static/css/style-mobile.css
@@ -75,3 +75,27 @@ body.dark-mode #sendModal .form-control {
   color: #ffffff;
   border-color: #444556;
 }
+
+/* ── Breadcrumb Pills ── */
+.breadcrumb-pills .breadcrumb-item {
+  background-color: #ffffff;
+  color: #212529;
+  padding: 0.25rem 0.75rem;
+  border-radius: 2rem;
+}
+.breadcrumb-pills .breadcrumb-item + .breadcrumb-item {
+  margin-left: 0.5rem;
+}
+.breadcrumb-pills .breadcrumb-item + .breadcrumb-item::before {
+  content: "\F285";
+  font-family: "bootstrap-icons";
+  color: #0d6efd;
+  padding-right: 0.25rem;
+}
+body.dark-mode .breadcrumb-pills .breadcrumb-item {
+  background-color: #2e3038;
+  color: #f5f5f5;
+}
+body.dark-mode .breadcrumb-pills .breadcrumb-item + .breadcrumb-item::before {
+  color: #64b5f6;
+}

--- a/web/static/css/style-phone.css
+++ b/web/static/css/style-phone.css
@@ -169,3 +169,27 @@ body.dark-mode #sendModal .form-control {
   color: #ffffff;
   border-color: #444556;
 }
+
+/* ── Breadcrumb Pills ── */
+.breadcrumb-pills .breadcrumb-item {
+  background-color: #fffdf8;
+  color: #212529;
+  padding: 0.25rem 0.75rem;
+  border-radius: 2rem;
+}
+.breadcrumb-pills .breadcrumb-item + .breadcrumb-item {
+  margin-left: 0.5rem;
+}
+.breadcrumb-pills .breadcrumb-item + .breadcrumb-item::before {
+  content: "\F285";
+  font-family: "bootstrap-icons";
+  color: #008cff;
+  padding-right: 0.25rem;
+}
+body.dark-mode .breadcrumb-pills .breadcrumb-item {
+  background-color: #2e3038;
+  color: #f5f5f5;
+}
+body.dark-mode .breadcrumb-pills .breadcrumb-item + .breadcrumb-item::before {
+  color: #64b5f6;
+}

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -404,3 +404,27 @@ body.dark-mode #fileSearch {
 body.dark-mode .expiration-cell small {
   color: var(--text-color-dark);
 }
+
+/* ── Breadcrumb Pills ── */
+.breadcrumb-pills .breadcrumb-item {
+  background-color: var(--card-bg-light);
+  color: var(--text-color-light);
+  padding: 0.25rem 0.75rem;
+  border-radius: 2rem;
+}
+.breadcrumb-pills .breadcrumb-item + .breadcrumb-item {
+  margin-left: 0.5rem;
+}
+.breadcrumb-pills .breadcrumb-item + .breadcrumb-item::before {
+  content: "\F285";
+  font-family: "bootstrap-icons";
+  color: var(--link-color-light);
+  padding-right: 0.25rem;
+}
+body.dark-mode .breadcrumb-pills .breadcrumb-item {
+  background-color: var(--card-bg-dark);
+  color: var(--text-color-dark);
+}
+body.dark-mode .breadcrumb-pills .breadcrumb-item + .breadcrumb-item::before {
+  color: var(--link-color-dark);
+}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -13,7 +13,7 @@
 <div class="container-fluid py-5">
   <!-- ★ パンくずリストで現在位置を明示 -->
   <nav aria-label="breadcrumb" class="mb-3">
-    <ol class="breadcrumb">
+    <ol class="breadcrumb breadcrumb-pills">
       <li class="breadcrumb-item"><a href="/">ホーム</a></li>
       {% for bc in breadcrumbs %}
         {% if not loop.last %}

--- a/web/templates/mobile/folder_view.html
+++ b/web/templates/mobile/folder_view.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <nav aria-label="breadcrumb" class="mb-2">
-  <ol class="breadcrumb mb-0">
+  <ol class="breadcrumb breadcrumb-pills mb-0">
     <li class="breadcrumb-item"><a href="/">ホーム</a></li>
     <li class="breadcrumb-item"><a href="/shared">共有フォルダ</a></li>
     <li class="breadcrumb-item active" aria-current="page">{{ folder_name }}</li>

--- a/web/templates/partials/home.html
+++ b/web/templates/partials/home.html
@@ -6,7 +6,7 @@
 <div class="container-fluid py-5">
   <!-- ★ パンくずリストで現在位置を明示 -->
   <nav aria-label="breadcrumb" class="mb-3">
-    <ol class="breadcrumb">
+    <ol class="breadcrumb breadcrumb-pills">
       <li class="breadcrumb-item"><a href="/">ホーム</a></li>
       <li class="breadcrumb-item"><a href="/shared">共有フォルダ</a></li>
       <li class="breadcrumb-item active" aria-current="page">{{ folder_name }}</li>

--- a/web/templates/shared/folder_view.html
+++ b/web/templates/shared/folder_view.html
@@ -7,7 +7,7 @@
 
   <!-- ★ パンくずリストで現在位置を明示 -->
   <nav aria-label="breadcrumb" class="mb-3">
-    <ol class="breadcrumb">
+    <ol class="breadcrumb breadcrumb-pills">
       <li class="breadcrumb-item"><a href="/">ホーム</a></li>
       <li class="breadcrumb-item"><a href="/shared">共有フォルダ</a></li>
       <li class="breadcrumb-item active" aria-current="page">{{ folder_name }}</li>

--- a/web/templates/shared/index.html
+++ b/web/templates/shared/index.html
@@ -8,7 +8,7 @@
   <div class="container-fluid py-5">
     <!-- ★ パンくずリストで現在位置を明示 -->
     <nav aria-label="breadcrumb" class="mb-3">
-      <ol class="breadcrumb">
+      <ol class="breadcrumb breadcrumb-pills">
         <li class="breadcrumb-item"><a href="/">ホーム</a></li>
         <li class="breadcrumb-item"><a href="/shared">共有フォルダ</a></li>
         <li class="breadcrumb-item active" aria-current="page">{{ folder_name }}</li>


### PR DESCRIPTION
## Summary
- style breadcrumb navigation using new `.breadcrumb-pills` class
- apply new style across templates
- cover breadcrumb styles with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687864767ab4832cbfa62403dd5333d1