### PR TITLE
Update auto tagging limits and skip executables

### DIFF
--- a/bot/auto_tag.py
+++ b/bot/auto_tag.py
@@ -43,9 +43,9 @@ def generate_tags(file_path: Path, original_name: str | None = None) -> str:
         generation_config=gen_cfg,
     )
 
-    # ファイルサイズが 1GB 以上ならタグ付けをスキップ
+    # ファイルサイズが 500MB 以上ならタグ付けをスキップ
     try:
-        if file_path.stat().st_size >= 1_000_000_000:
+        if file_path.stat().st_size >= 500_000_000:
             return ""
     except Exception:
         return ""
@@ -147,6 +147,10 @@ def generate_tags(file_path: Path, original_name: str | None = None) -> str:
 
     # 2-3) Gemini がサポートしていない ZIP ファイルはタグ生成をスキップ
     if mime == "application/zip":
+        return ""
+
+    # 2-4) 実行ファイルはセキュリティ上スキップ
+    if mime in {"application/x-msdos-program", "application/x-msdownload"}:
         return ""
 
     # 3) MIME 未判定だがテキストとして解釈できる場合


### PR DESCRIPTION
## Summary
- set Gemini tagging size limit to 500MB
- skip Gemini tagging for executable files
- test new skip rules for zip and exe files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68788d9ae768832c9db075b41daff0b9