### PR TITLE
Fix folder create realtime reload

### DIFF
--- a/tests/test_create_folder_broadcast.py
+++ b/tests/test_create_folder_broadcast.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import re
+
+APP = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+
+def test_create_folder_triggers_reload():
+    text = APP.read_text(encoding='utf-8')
+    pattern = re.compile(r"async def create_folder.*broadcast_ws\(\{\"action\": \"reload\"\}\)", re.S)
+    assert pattern.search(text)

--- a/web/app.py
+++ b/web/app.py
@@ -2607,6 +2607,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
             raise web.HTTPBadRequest()
         parent_id = int(parent) if parent else None
         await db.create_user_folder(user_id, name, parent_id)
+        await broadcast_ws({"action": "reload"})
         raise web.HTTPFound(request.headers.get("Referer", "/"))
 
     async def delete_folder(request: web.Request):


### PR DESCRIPTION
## Summary
- ensure new folders trigger websocket reloads
- test create folder broadcast

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68789b845fc4832cae790218338ae1dd