### PR TITLE
Implement websocket reload

### DIFF
--- a/tests/test_create_folder_broadcast.py
+++ b/tests/test_create_folder_broadcast.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+import re
+
+APP = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+def test_create_folder_triggers_reload():
+    text = APP.read_text(encoding='utf-8')
+    pattern = re.compile(r"async def create_folder.*broadcast_ws\(\{\"action\": \"reload\"\}\)", re.S)
+    assert pattern.search(text)

--- a/tests/test_rename_broadcast.py
+++ b/tests/test_rename_broadcast.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import re
+
+APP = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+
+def test_rename_file_triggers_reload():
+    text = APP.read_text(encoding='utf-8')
+    pattern = re.compile(r"async def rename_file.*broadcast_ws\(\{\"action\": \"reload\"\}\)", re.S)
+    assert pattern.search(text)
+
+
+def test_rename_shared_triggers_reload():
+    text = APP.read_text(encoding='utf-8')
+    pattern = re.compile(r"async def rename_shared_file.*broadcast_ws\(\{\"action\": \"reload\"\}\)", re.S)
+    assert pattern.search(text)

--- a/tests/test_toggle_shared_broadcast.py
+++ b/tests/test_toggle_shared_broadcast.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import re
+
+APP = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+def test_toggle_shared_triggers_reload():
+    text = APP.read_text(encoding='utf-8')
+    pattern = re.compile(r"async def toggle_shared.*broadcast_ws\(\{\"action\": \"reload\"\}\)", re.S)
+    assert pattern.search(text)
+
+def test_shared_toggle_triggers_reload():
+    text = APP.read_text(encoding='utf-8')
+    pattern = re.compile(r"async def shared_toggle.*broadcast_ws\(\{\"action\": \"reload\"\}\)", re.S)
+    assert pattern.search(text)

--- a/tests/test_update_tags_broadcast.py
+++ b/tests/test_update_tags_broadcast.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import re
+
+APP = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+def test_update_tags_triggers_reload():
+    text = APP.read_text(encoding='utf-8')
+    pattern = re.compile(r"async def update_tags.*broadcast_ws\(\{\"action\": \"reload\"\}\)", re.S)
+    assert pattern.search(text)
+
+def test_shared_update_tags_triggers_reload():
+    text = APP.read_text(encoding='utf-8')
+    pattern = re.compile(r"async def shared_update_tags.*broadcast_ws\(\{\"action\": \"reload\"\}\)", re.S)
+    assert pattern.search(text)

--- a/web/app.py
+++ b/web/app.py
@@ -2528,6 +2528,8 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         )
         await db.commit()
 
+        await broadcast_ws({"action": "reload"})
+
         return web.json_response({"status": "ok", "new_name": new_name})
 
     async def rename_shared_file(request: web.Request):
@@ -2592,6 +2594,8 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
             f"\N{PENCIL} <@{discord_id}> が `{sf['file_name']}` を `{new_name}` にリネームしました。",
         )
 
+        await broadcast_ws({"action": "reload"})
+
         return web.json_response({"status": "ok", "new_name": new_name})
 
     async def create_folder(request: web.Request):
@@ -2607,6 +2611,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
             raise web.HTTPBadRequest()
         parent_id = int(parent) if parent else None
         await db.create_user_folder(user_id, name, parent_id)
+        await broadcast_ws({"action": "reload"})
         raise web.HTTPFound(request.headers.get("Referer", "/"))
 
     async def delete_folder(request: web.Request):

--- a/web/app.py
+++ b/web/app.py
@@ -1892,6 +1892,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
                 file_id,
             )
         await request.app["db"].commit()
+        await broadcast_ws({"action": "reload"})
 
         payload = {"status": "ok", "is_shared": new_state, "expiration": exp_sec}
         if token:
@@ -2102,6 +2103,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         data = await req.post()
         tags = data.get("tags", "")
         await req.app["db"].update_tags(file_id, tags)
+        await broadcast_ws({"action": "reload"})
         return web.json_response({"status": "ok", "tags": tags})
 
     async def send_file_dm(req: web.Request):
@@ -2185,6 +2187,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         data = await req.post()
         tags = data.get("tags", "")
         await db.update_shared_tags(file_id, tags)
+        await broadcast_ws({"action": "reload"})
         return web.json_response({"status": "ok", "tags": tags})
 
     async def shared_upload(req: web.Request):
@@ -2470,6 +2473,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
                 file_id,
             )
         await db.commit()
+        await broadcast_ws({"action": "reload"})
 
         action = "共有しました" if new_state else "共有を解除しました"
         await _send_shared_webhook(


### PR DESCRIPTION
## Summary
- broadcast reload after rename or creating folders so other clients stay in sync
- test that renaming or creating folders triggers a websocket reload message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68789fe70b9c832c8f52c3783f788ebc