### PR TITLE
Fix tag input update timing

### DIFF
--- a/tests/test_tag_input_change.py
+++ b/tests/test_tag_input_change.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+import re
+
+JS = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'js' / 'main.js'
+
+def test_tag_input_updates_on_change():
+    text = JS.read_text(encoding='utf-8')
+    pattern = re.compile(r'document\.addEventListener\("change".*classList\.contains\("tag-input"\)', re.S)
+    assert pattern.search(text)

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -662,7 +662,11 @@ document.addEventListener("click", async (e) => {
 document.addEventListener("input", e => {
     if (e.target.id === "fileSearch") {
       filterTable(e.target.value.toLowerCase());
-    } else if (e.target.classList.contains("tag-input")) {
+    }
+  });
+
+document.addEventListener("change", e => {
+    if (e.target.classList.contains("tag-input")) {
       const fid  = e.target.dataset.fileId;
       const isShared = e.target.dataset.shared === "1";
       const form = new FormData();


### PR DESCRIPTION
## Summary
- update main.js to send tag updates on `change` instead of `input`
- add regression test for new event

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878a63b97d0832c846ccbf687f87946