### PR TITLE
Fix PC share toggle CSRF

### DIFF
--- a/tests/test_toggle_refresh_csrf.py
+++ b/tests/test_toggle_refresh_csrf.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+import re
+
+JS = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'js' / 'main.js'
+
+def test_handle_toggle_refreshes_csrf():
+    text = JS.read_text(encoding='utf-8')
+    pattern = re.compile(r"async function handleToggle.*refreshCsrfToken", re.S)
+    assert pattern.search(text)

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -355,6 +355,7 @@ async function handleToggle(toggle, expiration) {
   const fileId = toggle.dataset.fileId;
   const url    = toggle.dataset.url;
   try {
+    await refreshCsrfToken();
     const res = await fetch(url, {
       method:      "POST",
       credentials: "same-origin",


### PR DESCRIPTION
## Summary
- refresh CSRF token before calling the share toggle API
- add regression test for CSRF refresh in handleToggle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878c4961634832cbb37d9833dd68641