### PR TITLE
Fix shared folder download and reload behavior

### DIFF
--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -133,6 +133,7 @@ let isUploading = false;
 let progWrap = null;
 let progBar  = null;
 let userList = [];
+let lastReload = 0;
 
 // ―― ファイル一覧を再描画 ――
 async function reloadFileList() {
@@ -427,8 +428,9 @@ async function handleToggle(toggle, expiration) {
         : `<span class="text-muted">非共有</span>`;
     }
 
-    // 共有状態が変わった旨の通知は WebSocket からも届くため、
-    // ここではリスト更新を行わない
+    // 一覧を更新して共有リンクを反映
+    await reloadFileList();
+    lastReload = Date.now();
   } catch (err) {
     let msg = err && err.message ? err.message : String(err);
     if (msg === 'Failed to fetch') {
@@ -783,7 +785,9 @@ function connectWs() {
     try {
       const data = JSON.parse(e.data);
       if (data.action === 'reload') {
-        reloadFileList();
+        if (Date.now() - lastReload > 1000) {
+          reloadFileList();
+        }
       } else if (
         data.action === 'qr_login' &&
         typeof qTok !== 'undefined' &&

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -427,8 +427,8 @@ async function handleToggle(toggle, expiration) {
         : `<span class="text-muted">非共有</span>`;
     }
 
-    // 共有状態が変わった際はプレビューURLも変わるため一覧を再取得
-    await reloadFileList();
+    // 共有状態が変わった旨の通知は WebSocket からも届くため、
+    // ここではリスト更新を行わない
   } catch (err) {
     let msg = err && err.message ? err.message : String(err);
     if (msg === 'Failed to fetch') {

--- a/web/templates/partials/shared_folder_table.html
+++ b/web/templates/partials/shared_folder_table.html
@@ -85,7 +85,7 @@
             <td class="text-end" title="{{ f.size }} B">{{ f.size|human_size }}</td>
 
             <td class="text-center">
-              <a href="{{ f.download_url }}" class="btn btn-sm btn-outline-primary ripple" data-mdb-ripple-init title="ダウンロード">
+              <a href="{{ f.download_url }}" class="btn btn-sm btn-outline-primary ripple" data-mdb-ripple-init title="ダウンロード" target="_blank" rel="noopener">
                 <i class="bi bi-download"></i>
               </a>
             </td>


### PR DESCRIPTION
## Summary
- open shared file downloads in a new tab
- avoid duplicate reload on share toggle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b10e6e7dc832c9e0b17cdd6186ecb