### PR TITLE
統一した共有フォルダDLボタン

### DIFF
--- a/tests/test_shared_download_confirm.py
+++ b/tests/test_shared_download_confirm.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+
+def test_shared_download_button_opens_confirm_page():
+    text = APP_PATH.read_text(encoding='utf-8')
+    start = text.index('プレビュー用は inline')
+    snippet = text[start:start + 120]
+    assert '?dl=1' not in snippet

--- a/web/app.py
+++ b/web/app.py
@@ -822,7 +822,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
                 f["download_path"] = f"/shared/download/{token}"
                 f["preview_url"] = f"{f['download_path']}?preview=1"
                 f["download_url"] = _make_download_url(
-                    f"{f['download_path']}?dl=1", external=True
+                    f["download_path"], external=True
                 )
                 preview_fallback = f["preview_url"]
             else:


### PR DESCRIPTION
## Summary
- avoid auto-download in shared folder view by removing `?dl=1`
- add regression test to ensure shared downloads open confirmation page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b3646536c832cac9b6f258efb7afb