### PR TITLE
Fix cleanup to ignore shared files

### DIFF
--- a/tests/test_orphan_cleanup.py
+++ b/tests/test_orphan_cleanup.py
@@ -9,3 +9,8 @@ def test_orphan_cleanup_task_defined():
     assert 'asyncio.create_task(_cleanup_orphan_files(app))' in text
     assert 'DATA_DIR.iterdir()' in text
     assert 'p == DB_PATH' in text or 'DB_PATH' in text
+
+
+def test_orphan_cleanup_checks_shared_files():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert 'SELECT path FROM shared_files' in text

--- a/web/app.py
+++ b/web/app.py
@@ -349,6 +349,9 @@ async def _cleanup_orphan_files(app: web.Application) -> None:
                 valid_paths = {
                     r["path"] for r in await db.fetchall("SELECT path FROM files")
                 }
+                valid_paths.update(
+                    r["path"] for r in await db.fetchall("SELECT path FROM shared_files")
+                )
             else:
                 valid_paths = set()
 


### PR DESCRIPTION
## Summary
- keep shared files when cleaning orphan files
- check `shared_files` table in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b3acafc2c832c983daa1da3e5fc0c