### PR TITLE
共有切替時の二重リロード修正

### DIFF
--- a/tests/test_ws_skip_reload.py
+++ b/tests/test_ws_skip_reload.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import re
+
+JS = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'js' / 'main.js'
+
+
+def test_skip_flag_defined():
+    text = JS.read_text(encoding='utf-8')
+    assert 'let wsSkipReload' in text
+
+
+def test_handle_toggle_sets_flag():
+    text = JS.read_text(encoding='utf-8')
+    pattern = re.compile(r"async function handleToggle.*wsSkipReload\s*=\s*true", re.S)
+    assert pattern.search(text)

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -429,6 +429,7 @@ async function handleToggle(toggle, expiration) {
 
     // 共有状態が変わった際はプレビューURLも変わるため一覧を再取得
     await reloadFileList();
+    wsSkipReload = true;
   } catch (err) {
     let msg = err && err.message ? err.message : String(err);
     if (msg === 'Failed to fetch') {
@@ -775,6 +776,7 @@ if (sendExecBtn) {
 })();
 
 let ws;
+let wsSkipReload = false;
 function connectWs() {
   if (ws) return;
   const proto = location.protocol === 'https:' ? 'wss' : 'ws';
@@ -783,7 +785,10 @@ function connectWs() {
     try {
       const data = JSON.parse(e.data);
       if (data.action === 'reload') {
-        reloadFileList();
+        if (!wsSkipReload) {
+          reloadFileList();
+        }
+        wsSkipReload = false;
       } else if (
         data.action === 'qr_login' &&
         typeof qTok !== 'undefined' &&


### PR DESCRIPTION
## Summary
- WS 更新通知で再読み込みが重複していたため、フラグ `wsSkipReload` を追加
- `handleToggle` で一覧更新後にフラグを立て、WS 側で一度だけリロードするよう調整
- 新しいテスト `test_ws_skip_reload` を追加し、フラグの存在と設定を確認

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b3c78c0f0832c85474ea773edfdbe