### PR TITLE
Refactor shared folder downloads

### DIFF
--- a/tests/test_shared_folder_private_download.py
+++ b/tests/test_shared_folder_private_download.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import re
+
+APP = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+
+def test_shared_folder_download_uses_private_link():
+    text = APP.read_text(encoding='utf-8')
+    pattern = re.compile(
+        "async def shared_folder_view[\\s\\S]+?f\\[\\\"download_path\\\"\\] = f\\\"/download/",
+        re.S,
+    )
+    assert pattern.search(text)
+    assert 'download_path"] = f"/shared/download' not in text


### PR DESCRIPTION
## Summary
- use private download token in `shared_folder_view`
- add regression test for private download token

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882d02ed914832c968657ace29dc722