### PR TITLE
Update shared folder download handling

### DIFF
--- a/tests/test_shared_folder_private_download.py
+++ b/tests/test_shared_folder_private_download.py
@@ -4,11 +4,7 @@ import re
 APP = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
 
 
-def test_shared_folder_download_uses_private_link():
+def test_shared_folder_uses_file_to_dict_external():
     text = APP.read_text(encoding='utf-8')
-    pattern = re.compile(
-        "async def shared_folder_view[\\s\\S]+?f\\[\\\"download_path\\\"\\] = f\\\"/download/",
-        re.S,
-    )
+    pattern = re.compile(r"async def shared_folder_view[\s\S]+?_file_to_dict\([^\n]*external=True", re.S)
     assert pattern.search(text)
-    assert 'download_path"] = f"/shared/download' not in text


### PR DESCRIPTION
## Summary
- extend `_file_to_dict` with `external` flag to control download domain
- use `external=True` when rendering shared folders
- simplify shared folder view logic
- adjust test to ensure `_file_to_dict` is called with `external=True`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882db321248832c89d3bd8ad31cc242