### PR TITLE
Fix double reload on shared folder toggle

### DIFF
--- a/tests/test_toggle_flag_order.py
+++ b/tests/test_toggle_flag_order.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+import re
+
+JS = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'js' / 'main.js'
+
+def test_ws_flag_set_before_fetch():
+    text = JS.read_text(encoding='utf-8')
+    pattern = re.compile(r"async function handleToggle[\s\S]*wsSkipReload\s*=\s*true[\s\S]*fetch\(", re.S)
+    assert pattern.search(text)

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -354,6 +354,8 @@ window.addEventListener("DOMContentLoaded", startExpirationCountdowns);
 async function handleToggle(toggle, expiration) {
   const fileId = toggle.dataset.fileId;
   const url    = toggle.dataset.url;
+  // 先にフラグを立てて WS の reload を1回だけ無視
+  wsSkipReload = true;
   try {
     await refreshCsrfToken();
     const res = await fetch(url, {


### PR DESCRIPTION
## Summary
- prevent double reload when toggling shared files by setting `wsSkipReload` before the fetch call
- test that the flag is set before fetching to avoid double reload

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882dec5aef0832cb0b0dc4508f31357