### PR TITLE
CSRFミドルウェアを一時的に無効化

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -479,7 +479,8 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
     session_setup(app, storage)
 
     # middlewares
-    app.middlewares.append(csrf_protect_mw)
+    # CSRF検証を一時的に無効化
+    # app.middlewares.append(csrf_protect_mw)
     app.middlewares.append(auth_mw)
     app.middlewares.append(rl_mw)  # DoS / ブルートフォース緩和
     app.middlewares.append(csp_mw)


### PR DESCRIPTION
## Summary
- コメントアウトでCSRF検証を一時的に停止

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc3a95c38832cb1ea6fce701e4a8e